### PR TITLE
Fix bug with size in UKModalController

### DIFF
--- a/Sources/ComponentsKit/Components/Alert/SUAlert.swift
+++ b/Sources/ComponentsKit/Components/Alert/SUAlert.swift
@@ -71,7 +71,7 @@ extension View {
           },
           footer: {
             switch AlertButtonsOrientationCalculator.preferredOrientation(model: model) {
-              case .horizontal:
+            case .horizontal:
               HStack(spacing: AlertVM.buttonsSpacing) {
                 AlertButton(
                   isAlertPresented: isPresented,


### PR DESCRIPTION
You can notice this bug in the `sualert` branch where setting a longer title for a primary button causes the alert's width to exceed the `maxWidth` value. This issue likely arises from the stackView's width priority being higher than that of the modal's container.

To resolve this bug, the container's constraint priority is set to `.required` when the modal's size is smaller than the screen's size. To prevent constraint breaks when the device orientation changes, the constraint deactivates in the `viewWillTransition` method.