### PR TITLE
Fix breaking layout in Countdown

### DIFF
--- a/Sources/ComponentsKit/Components/Countdown/Helpers/CountdownWidthCalculator.swift
+++ b/Sources/ComponentsKit/Components/Countdown/Helpers/CountdownWidthCalculator.swift
@@ -9,15 +9,16 @@ struct CountdownWidthCalculator {
     for attributedText: NSAttributedString,
     model: CountdownVM
   ) -> CGFloat {
-    self.style(label, with: model)
+    self.style(self.label, with: model)
     self.label.attributedText = attributedText
 
     let estimatedSize = self.label.sizeThatFits(UIView.layoutFittingExpandedSize)
 
-    return estimatedSize.width
+    return estimatedSize.width + 2
   }
 
   private static func style(_ label: UILabel, with model: CountdownVM) {
+    label.textAlignment = .center
     label.numberOfLines = 0
   }
 }

--- a/Sources/ComponentsKit/Components/Countdown/SUCountdown.swift
+++ b/Sources/ComponentsKit/Components/Countdown/SUCountdown.swift
@@ -28,11 +28,11 @@ public struct SUCountdown: View {
       switch (self.model.style, self.model.unitsStyle) {
       case (.plain, .bottom):
         self.styledTime(value: self.manager.days, unit: .days)
-        colonView
+        self.colonView
         self.styledTime(value: self.manager.hours, unit: .hours)
-        colonView
+        self.colonView
         self.styledTime(value: self.manager.minutes, unit: .minutes)
-        colonView
+        self.colonView
         self.styledTime(value: self.manager.seconds, unit: .seconds)
 
       case (.plain, .hidden), (.plain, .trailing):


### PR DESCRIPTION
This PR resolves an issue where the layout of the `Countdown` component could break under certain conditions.

<img src="https://github.com/user-attachments/assets/17f4e6da-3f3b-4c24-afb5-f5bf9d424dba" height="400" />

The issue occurred when the unit text was shorter than the time value. The bug appeared because the cell width was calculated only once on appear and when model changes. However, the width of digits can vary, and as the value changes every second, it could exceed the initially calculated width.

### Ideal Solution
The optimal solution would be to recalculate the width dynamically every time the value changes. However, this approach would significantly increase resource usage, which may not be ideal for all devices.

### Fix Implemented
To address this, a small value to the initially calculated width is added. While this is not a perfect solution, it should work in most cases. We will monitor this fix, and if the issue appear in the future, we will explore alternative approaches.
