### PR TITLE
Use superview's width in fullwidth components only when it's greater than 0

### DIFF
--- a/Sources/ComponentsKit/Components/ProgressBar/UKProgressBar.swift
+++ b/Sources/ComponentsKit/Components/ProgressBar/UKProgressBar.swift
@@ -182,7 +182,13 @@ open class UKProgressBar: UIView, UKComponent {
   // MARK: - UIView methods
 
   open override func sizeThatFits(_ size: CGSize) -> CGSize {
-    let width = self.superview?.bounds.width ?? size.width
+    let width: CGFloat
+    if let parentWidth = self.superview?.bounds.width,
+       parentWidth > 0 {
+      width = parentWidth
+    } else {
+      width = 10_000
+    }
     return CGSize(
       width: min(size.width, width),
       height: min(size.height, self.model.backgroundHeight)

--- a/Sources/ComponentsKit/Components/Slider/UKSlider.swift
+++ b/Sources/ComponentsKit/Components/Slider/UKSlider.swift
@@ -193,7 +193,13 @@ open class UKSlider: UIView, UKComponent {
   // MARK: - UIView Methods
 
   open override func sizeThatFits(_ size: CGSize) -> CGSize {
-    let width = self.superview?.bounds.width ?? size.width
+    let width: CGFloat
+    if let parentWidth = self.superview?.bounds.width,
+       parentWidth > 0 {
+      width = parentWidth
+    } else {
+      width = 10_000
+    }
     return CGSize(
       width: min(size.width, width),
       height: min(size.height, self.model.handleSize.height)


### PR DESCRIPTION
This bug led to invalid layout in `UKProgressBar` and `UKSlider`