### PR TITLE
Add new alert API

### DIFF
--- a/Sources/ComponentsKit/Components/Alert/SUAlert.swift
+++ b/Sources/ComponentsKit/Components/Alert/SUAlert.swift
@@ -1,5 +1,133 @@
 import SwiftUI
 
+struct AlertContent: View {
+  @Binding var isPresented: Bool
+  let model: AlertVM
+  let primaryAction: (() -> Void)?
+  let secondaryAction: (() -> Void)?
+
+  var body: some View {
+    SUCenterModal(
+      isVisible: self.$isPresented,
+      model: self.model.modalVM,
+      header: {
+        if self.model.message.isNotNil,
+           let text = self.model.title {
+          self.title(text)
+        }
+      },
+      body: {
+        if let text = self.model.message {
+          self.message(text)
+        } else if let text = self.model.title {
+          self.title(text)
+        }
+      },
+      footer: {
+        switch AlertButtonsOrientationCalculator.preferredOrientation(model: model) {
+        case .horizontal:
+          HStack(spacing: AlertVM.buttonsSpacing) {
+            self.button(
+              model: self.model.secondaryButtonVM,
+              action: self.secondaryAction
+            )
+            self.button(
+              model: self.model.primaryButtonVM,
+              action: self.primaryAction
+            )
+          }
+        case .vertical:
+          VStack(spacing: AlertVM.buttonsSpacing) {
+            self.button(
+              model: self.model.primaryButtonVM,
+              action: self.primaryAction
+            )
+            self.button(
+              model: self.model.secondaryButtonVM,
+              action: self.secondaryAction
+            )
+          }
+        }
+      }
+    )
+  }
+
+  // MARK: - Helpers
+
+  func title(_ text: String) -> some View {
+    Text(text)
+      .font(UniversalFont.mdHeadline.font)
+      .foregroundStyle(UniversalColor.foreground.color)
+      .multilineTextAlignment(.center)
+      .frame(maxWidth: .infinity)
+  }
+
+  func message(_ text: String) -> some View {
+    Text(text)
+      .font(UniversalFont.mdBody.font)
+      .foregroundStyle(UniversalColor.secondaryForeground.color)
+      .multilineTextAlignment(.center)
+      .frame(maxWidth: .infinity)
+  }
+
+  func button(
+    model: ButtonVM?,
+    action: (() -> Void)?
+  ) -> some View {
+    Group {
+      if let model {
+        SUButton(model: model) {
+          action?()
+          self.isPresented = false
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Helpers
+
+private struct AlertTitle: View {
+  let text: String
+
+  var body: some View {
+    Text(self.text)
+      .font(UniversalFont.mdHeadline.font)
+      .foregroundStyle(UniversalColor.foreground.color)
+      .multilineTextAlignment(.center)
+      .frame(maxWidth: .infinity)
+  }
+}
+
+private struct AlertMessage: View {
+  let text: String
+
+  var body: some View {
+    Text(self.text)
+      .font(UniversalFont.mdBody.font)
+      .foregroundStyle(UniversalColor.secondaryForeground.color)
+      .multilineTextAlignment(.center)
+      .frame(maxWidth: .infinity)
+  }
+}
+
+private struct AlertButton: View {
+  @Binding var isAlertPresented: Bool
+  let model: ButtonVM?
+  let action: (() -> Void)?
+
+  var body: some View {
+    if let model {
+      SUButton(model: model) {
+        self.action?()
+        self.isAlertPresented = false
+      }
+    }
+  }
+}
+
+// MARK: - Presentation Helpers
+
 extension View {
   /// A SwiftUI view modifier that presents an alert with a title, message, and up to two action buttons.
   ///
@@ -53,95 +181,95 @@ extension View {
       transitionDuration: model.transition.value,
       onDismiss: onDismiss,
       content: {
-        SUCenterModal(
-          isVisible: isPresented,
-          model: model.modalVM,
-          header: {
-            if model.message.isNotNil,
-               let title = model.title {
-              AlertTitle(text: title)
-            }
-          },
-          body: {
-            if let message = model.message {
-              AlertMessage(text: message)
-            } else if let title = model.title {
-              AlertTitle(text: title)
-            }
-          },
-          footer: {
-            switch AlertButtonsOrientationCalculator.preferredOrientation(model: model) {
-            case .horizontal:
-              HStack(spacing: AlertVM.buttonsSpacing) {
-                AlertButton(
-                  isAlertPresented: isPresented,
-                  model: model.secondaryButtonVM,
-                  action: secondaryAction
-                )
-                AlertButton(
-                  isAlertPresented: isPresented,
-                  model: model.primaryButtonVM,
-                  action: primaryAction
-                )
-              }
-            case .vertical:
-              VStack(spacing: AlertVM.buttonsSpacing) {
-                AlertButton(
-                  isAlertPresented: isPresented,
-                  model: model.primaryButtonVM,
-                  action: primaryAction
-                )
-                AlertButton(
-                  isAlertPresented: isPresented,
-                  model: model.secondaryButtonVM,
-                  action: secondaryAction
-                )
-              }
-            }
-          }
+        AlertContent(
+          isPresented: isPresented,
+          model: model,
+          primaryAction: primaryAction,
+          secondaryAction: secondaryAction
         )
       }
     )
   }
-}
 
-// MARK: - Helpers
-
-private struct AlertTitle: View {
-  let text: String
-
-  var body: some View {
-    Text(self.text)
-      .font(UniversalFont.mdHeadline.font)
-      .foregroundStyle(UniversalColor.foreground.color)
-      .multilineTextAlignment(.center)
-      .frame(maxWidth: .infinity)
-  }
-}
-
-private struct AlertMessage: View {
-  let text: String
-
-  var body: some View {
-    Text(self.text)
-      .font(UniversalFont.mdBody.font)
-      .foregroundStyle(UniversalColor.secondaryForeground.color)
-      .multilineTextAlignment(.center)
-      .frame(maxWidth: .infinity)
-  }
-}
-
-private struct AlertButton: View {
-  @Binding var isAlertPresented: Bool
-  let model: ButtonVM?
-  let action: (() -> Void)?
-
-  var body: some View {
-    if let model {
-      SUButton(model: model) {
-        self.action?()
-        self.isAlertPresented = false
+  /// A SwiftUI view modifier that presents an alert with a title, message, and up to two action buttons.
+  ///
+  /// All actions in an alert dismiss the alert after the action runs. If no actions are present, a standard “OK” action is included.
+  ///
+  /// - Parameters:
+  ///   - isPresented: A binding that determines whether the alert is presented.
+  ///   - item: A binding to an optional `Item` that determines whether the alert is presented.
+  ///           When `item` is `nil`, the alert is hidden.
+  ///   - primaryAction: An optional closure executed when the primary button is tapped.
+  ///   - secondaryAction: An optional closure executed when the secondary button is tapped.
+  ///   - onDismiss: An optional closure executed when the alert is dismissed.
+  ///
+  /// - Example:
+  ///   ```swift
+  ///   struct ContentView: View {
+  ///     struct AlertData: Identifiable {
+  ///       var id: String {
+  ///         return text
+  ///       }
+  ///       let text: String
+  ///     }
+  ///
+  ///     @State private var selectedItem: AlertData?
+  ///     private let items: [AlertData] = [
+  ///       AlertData(text: "data 1"),
+  ///       AlertData(text: "data 2")
+  ///     ]
+  ///
+  ///     var body: some View {
+  ///       List(items) { item in
+  ///         Button("Show Alert") {
+  ///           selectedItem = item
+  ///         }
+  ///       }
+  ///       .suAlert(
+  ///         item: $selectedItem,
+  ///         model: { data in
+  ///           return AlertVM {
+  ///             $0.title = "Data Preview"
+  ///             $0.message = data.text
+  ///           }
+  ///         },
+  ///         onDismiss: {
+  ///           print("Alert dismissed")
+  ///         }
+  ///       )
+  ///     }
+  ///   }
+  ///   ```
+  public func suAlert<Item: Identifiable>(
+    item: Binding<Item?>,
+    model: @escaping (Item) -> AlertVM,
+    primaryAction: ((Item) -> Void)? = nil,
+    secondaryAction: ((Item) -> Void)? = nil,
+    onDismiss: (() -> Void)? = nil
+  ) -> some View {
+    return self.modal(
+      item: item,
+      transitionDuration: { model($0).transition.value },
+      onDismiss: onDismiss,
+      content: { unwrappedItem in
+        AlertContent(
+          isPresented: .init(
+            get: {
+              return item.wrappedValue.isNotNil
+            },
+            set: { isPresented in
+              if isPresented {
+                item.wrappedValue = unwrappedItem
+              } else {
+                item.wrappedValue = nil
+              }
+            }
+          ),
+          model: model(unwrappedItem),
+          primaryAction: { primaryAction?(unwrappedItem) },
+          secondaryAction: { secondaryAction?(unwrappedItem) }
+        )
       }
-    }
+    )
   }
 }

--- a/Sources/ComponentsKit/Components/Alert/SUAlert.swift
+++ b/Sources/ComponentsKit/Components/Alert/SUAlert.swift
@@ -85,47 +85,6 @@ struct AlertContent: View {
   }
 }
 
-// MARK: - Helpers
-
-private struct AlertTitle: View {
-  let text: String
-
-  var body: some View {
-    Text(self.text)
-      .font(UniversalFont.mdHeadline.font)
-      .foregroundStyle(UniversalColor.foreground.color)
-      .multilineTextAlignment(.center)
-      .frame(maxWidth: .infinity)
-  }
-}
-
-private struct AlertMessage: View {
-  let text: String
-
-  var body: some View {
-    Text(self.text)
-      .font(UniversalFont.mdBody.font)
-      .foregroundStyle(UniversalColor.secondaryForeground.color)
-      .multilineTextAlignment(.center)
-      .frame(maxWidth: .infinity)
-  }
-}
-
-private struct AlertButton: View {
-  @Binding var isAlertPresented: Bool
-  let model: ButtonVM?
-  let action: (() -> Void)?
-
-  var body: some View {
-    if let model {
-      SUButton(model: model) {
-        self.action?()
-        self.isAlertPresented = false
-      }
-    }
-  }
-}
-
 // MARK: - Presentation Helpers
 
 extension View {

--- a/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationModifier.swift
+++ b/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationModifier.swift
@@ -28,8 +28,8 @@ struct ModalPresentationModifier<Modal: View>: ViewModifier {
           self.isPresented = true
         }
       }
-      .onChange(of: self.isContentVisible) { newValue in
-        if newValue {
+      .onChange(of: self.isContentVisible) { isVisible in
+        if isVisible {
           self.isPresented = true
         } else {
           DispatchQueue.main.asyncAfter(deadline: .now() + self.transitionDuration) {

--- a/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationModifier.swift
+++ b/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationModifier.swift
@@ -23,6 +23,11 @@ struct ModalPresentationModifier<Modal: View>: ViewModifier {
 
   func body(content: Content) -> some View {
     content
+      .onAppear {
+        if self.isContentVisible {
+          self.isPresented = true
+        }
+      }
       .onChange(of: self.isContentVisible) { newValue in
         if newValue {
           self.isPresented = true

--- a/Sources/ComponentsKit/Components/Modal/SwiftUI/SUBottomModal.swift
+++ b/Sources/ComponentsKit/Components/Modal/SwiftUI/SUBottomModal.swift
@@ -195,7 +195,7 @@ extension View {
   ///       }
   ///       .bottomModal(
   ///         item: $selectedItem,
-  ///         model: BottomModalVM(),
+  ///         model: { _ in BottomModalVM() },
   ///         onDismiss: {
   ///           print("Modal dismissed")
   ///         },
@@ -218,7 +218,7 @@ extension View {
   ///   ```
   public func bottomModal<Item: Identifiable, Header: View, Body: View, Footer: View>(
     item: Binding<Item?>,
-    model: BottomModalVM = .init(),
+    model: @escaping (Item) -> BottomModalVM = { _ in .init() },
     onDismiss: (() -> Void)? = nil,
     @ViewBuilder header: @escaping (Item) -> Header,
     @ViewBuilder body: @escaping (Item) -> Body,
@@ -226,7 +226,7 @@ extension View {
   ) -> some View {
     return self.modal(
       item: item,
-      transitionDuration: model.transition.value,
+      transitionDuration: { model($0).transition.value },
       onDismiss: onDismiss,
       content: { unwrappedItem in
         SUBottomModal(
@@ -242,7 +242,7 @@ extension View {
               }
             }
           ),
-          model: model,
+          model: model(unwrappedItem),
           header: { header(unwrappedItem) },
           body: { body(unwrappedItem) },
           footer: { footer(unwrappedItem) }
@@ -289,7 +289,7 @@ extension View {
   ///       }
   ///       .bottomModal(
   ///         item: $selectedItem,
-  ///         model: BottomModalVM(),
+  ///         model: { _ in BottomModalVM() },
   ///         onDismiss: {
   ///           print("Modal dismissed")
   ///         },
@@ -302,7 +302,7 @@ extension View {
   ///   ```
   public func bottomModal<Item: Identifiable, Body: View>(
     item: Binding<Item?>,
-    model: BottomModalVM = .init(),
+    model: @escaping (Item) -> BottomModalVM = { _ in .init() },
     onDismiss: (() -> Void)? = nil,
     @ViewBuilder body: @escaping (Item) -> Body
   ) -> some View {

--- a/Sources/ComponentsKit/Components/Modal/SwiftUI/SUCenterModal.swift
+++ b/Sources/ComponentsKit/Components/Modal/SwiftUI/SUCenterModal.swift
@@ -157,7 +157,7 @@ extension View {
   ///       }
   ///       .centerModal(
   ///         item: $selectedItem,
-  ///         model: CenterModalVM(),
+  ///         model: { _ in CenterModalVM() },
   ///         onDismiss: {
   ///           print("Modal dismissed")
   ///         },
@@ -180,7 +180,7 @@ extension View {
   ///   ```
   public func centerModal<Item: Identifiable, Header: View, Body: View, Footer: View>(
     item: Binding<Item?>,
-    model: CenterModalVM = .init(),
+    model: @escaping (Item) -> CenterModalVM = { _ in .init() },
     onDismiss: (() -> Void)? = nil,
     @ViewBuilder header: @escaping (Item) -> Header,
     @ViewBuilder body: @escaping (Item) -> Body,
@@ -188,7 +188,7 @@ extension View {
   ) -> some View {
     return self.modal(
       item: item,
-      transitionDuration: model.transition.value,
+      transitionDuration: { model($0).transition.value },
       onDismiss: onDismiss,
       content: { unwrappedItem in
         SUCenterModal(
@@ -204,7 +204,7 @@ extension View {
               }
             }
           ),
-          model: model,
+          model: model(unwrappedItem),
           header: { header(unwrappedItem) },
           body: { body(unwrappedItem) },
           footer: { footer(unwrappedItem) }
@@ -251,7 +251,7 @@ extension View {
   ///       }
   ///       .centerModal(
   ///         item: $selectedItem,
-  ///         model: CenterModalVM(),
+  ///         model: { _ in CenterModalVM() },
   ///         onDismiss: {
   ///           print("Modal dismissed")
   ///         },
@@ -264,7 +264,7 @@ extension View {
   ///   ```
   public func centerModal<Item: Identifiable, Body: View>(
     item: Binding<Item?>,
-    model: CenterModalVM = .init(),
+    model: @escaping (Item) -> CenterModalVM = { _ in .init() },
     onDismiss: (() -> Void)? = nil,
     @ViewBuilder body: @escaping (Item) -> Body
   ) -> some View {


### PR DESCRIPTION
- added a new method to present an alert with `item`: 
```swift
func suAlert<Item>(
    item: Binding<Item?>,
    model: @escaping (Item) -> AlertVM,
    primaryAction: ((Item) -> Void)? = nil,
    secondaryAction: ((Item) -> Void)? = nil,
    onDismiss: (() -> Void)? = nil
) -> some View where Item : Identifiable
```
- changed methods to present modals with items: 
param `model: ModalVM`, replaced with `model: @escaping (Item) -> ModalVM`
- fixed bug where modals and alerts were not displayed at app launch when `isPresented = true`