### PR TITLE
Force modal's content take all available width

### DIFF
--- a/Examples/DemosApp/DemosApp/ComponentsPreview/Helpers/ModalPreview+Helpers.swift
+++ b/Examples/DemosApp/DemosApp/ComponentsPreview/Helpers/ModalPreview+Helpers.swift
@@ -203,16 +203,20 @@ Enim habitant laoreet inceptos scelerisque senectus, tellus molestie ut. Eros ri
   }
 
   static func suBody(body: ContentBody) -> some View {
-    Group {
-      switch body {
-      case .shortText:
-        Text(self.bodyShortText)
-      case .longText:
-        Text(self.bodyLongText)
+    HStack {
+      Group {
+        switch body {
+        case .shortText:
+          Text(self.bodyShortText)
+        case .longText:
+          Text(self.bodyLongText)
+        }
       }
+      .font(self.bodyFont.font)
+      .multilineTextAlignment(.leading)
+
+      Spacer()
     }
-    .font(self.bodyFont.font)
-    .multilineTextAlignment(.leading)
   }
 
   static func suFooter(

--- a/Sources/ComponentsKit/Components/Modal/SwiftUI/ModalContent.swift
+++ b/Sources/ComponentsKit/Components/Modal/SwiftUI/ModalContent.swift
@@ -43,7 +43,7 @@ struct ModalContent<VM: ModalVM, Header: View, Body: View, Footer: View>: View {
           .padding(.top, self.bodyTopPadding)
           .padding(.bottom, self.bodyBottomPadding)
       }
-      .frame(maxHeight: self.scrollViewMaxHeight)
+      .frame(maxWidth: .infinity, maxHeight: self.scrollViewMaxHeight)
       .disableScrollWhenContentFits()
 
       self.contentFooter()


### PR DESCRIPTION
Previously, if the content's width was smaller than the modal's width, it would align to the left. With this fix, the content now uses the full available width and centers itself.

Here's a sample code to test it:
```swift
struct App: View {
  @State var isModalPresented = false
  
  var body: some View {
    SUButton(model: .init {
      $0.title = "Show Modal"
    }) {
      isModalPresented = true
    }
    .bottomModal(
      isPresented: $isModalPresented,
      model: .init(),
      header: {
        Text("Header")
      },
      body: {
        Text("Body content goes here")
      },
      footer: {
        SUButton(model: .init {
          $0.title = "Close"
        }) {
          isModalPresented = false
        }
      }
    )
  }
}
```