### PR TITLE
Add inits without `focus` to `SUInputField` and `SUTextInput`

### DIFF
--- a/Sources/ComponentsKit/Components/TextInput/SUTextInput.swift
+++ b/Sources/ComponentsKit/Components/TextInput/SUTextInput.swift
@@ -14,7 +14,7 @@ public struct SUTextInput<FocusValue: Hashable>: View {
   ///
   /// When the `localFocus` value matches `globalFocus`, this text input becomes focused.
   /// This enables centralized focus management for multiple text inputs and input fields within a single view.
-  @FocusState.Binding public var globalFocus: FocusValue
+  public let globalFocus: FocusState<FocusValue>.Binding?
 
   /// The unique value for this field to match against the global focus state to determine whether this text input is focused.
   ///
@@ -24,7 +24,7 @@ public struct SUTextInput<FocusValue: Hashable>: View {
   ///
   /// - Warning: The `localFocus` value must be unique to each text input and input field, to ensure that different
   /// text inputs and input fields within the same view can be independently focused based on the shared `globalFocus`.
-  public var localFocus: FocusValue
+  public let localFocus: FocusValue
 
   @State private var textEditorPreferredHeight: CGFloat = 0
 
@@ -43,7 +43,7 @@ public struct SUTextInput<FocusValue: Hashable>: View {
     model: TextInputVM = .init()
   ) {
     self._text = text
-    self._globalFocus = globalFocus
+    self.globalFocus = globalFocus
     self.localFocus = localFocus
     self.model = model
   }
@@ -67,7 +67,7 @@ public struct SUTextInput<FocusValue: Hashable>: View {
         .font(self.model.preferredFont.font)
         .foregroundStyle(self.model.foregroundColor.color)
         .tint(self.model.tintColor.color)
-        .focused(self.$globalFocus, equals: self.localFocus)
+        .applyFocus(globalFocus: self.globalFocus, localFocus: self.localFocus)
         .disabled(!self.model.isEnabled)
         .keyboardType(self.model.keyboardType)
         .submitLabel(self.model.submitType.submitLabel)
@@ -154,6 +154,18 @@ extension View {
       UITextView.appearance().textContainer.lineFragmentPadding = 0
     }
   }
+
+  @ViewBuilder
+  fileprivate func applyFocus<FocusValue: Hashable>(
+    globalFocus: FocusState<FocusValue>.Binding?,
+    localFocus: FocusValue,
+  ) -> some View {
+    if let globalFocus {
+      self.focused(globalFocus, equals: localFocus)
+    } else {
+      self
+    }
+  }
 }
 
 // MARK: - Boolean Focus Value
@@ -170,7 +182,25 @@ extension SUTextInput where FocusValue == Bool {
     model: TextInputVM = .init()
   ) {
     self._text = text
-    self._globalFocus = isFocused
+    self.globalFocus = isFocused
+    self.localFocus = true
+    self.model = model
+  }
+}
+
+// MARK: - No Focus Value
+
+extension SUTextInput where FocusValue == Bool {
+  /// Initializer.
+  /// - Parameters:
+  ///   - text: A Binding value to control the inputted text.
+  ///   - model: A model that defines the appearance properties.
+  public init(
+    text: Binding<String>,
+    model: TextInputVM = .init()
+  ) {
+    self._text = text
+    self.globalFocus = nil
     self.localFocus = true
     self.model = model
   }

--- a/Sources/ComponentsKit/Components/TextInput/UKTextInput.swift
+++ b/Sources/ComponentsKit/Components/TextInput/UKTextInput.swift
@@ -205,8 +205,11 @@ extension UKTextInput {
     }
 
     static func textView(_ textView: UITextView, padding: CGFloat) {
-      textView.textContainerInset = .init(inset: padding)
       textView.textContainer.lineFragmentPadding = 0
+      textView.textContainerInset.top = padding
+      textView.textContainerInset.left = padding
+      textView.textContainerInset.right = padding
+      textView.textContainerInset.bottom = padding
     }
 
     static func placeholder(


### PR DESCRIPTION
As per title + fixed a bug when the top padding in `UKTextInput` was incorrect on devices with iOS 16