### PR TITLE
Properly handle `dismiss` in modals

### DIFF
--- a/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationModifier.swift
+++ b/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationModifier.swift
@@ -38,7 +38,10 @@ struct ModalPresentationModifier<Modal: View>: ViewModifier {
         }
       }
       .fullScreenCover(
-        isPresented: self.$isPresented,
+        isPresented: .init(
+          get: { self.isPresented },
+          set: { self.isContentVisible = $0 }
+        ),
         onDismiss: self.onDismiss,
         content: {
           self.content()

--- a/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationWithItemModifier.swift
+++ b/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationWithItemModifier.swift
@@ -39,7 +39,10 @@ struct ModalPresentationWithItemModifier<Modal: View, Item: Identifiable>: ViewM
         }
       }
       .fullScreenCover(
-        item: self.$presentedItem,
+        item: .init(
+          get: { self.presentedItem },
+          set: { self.visibleItem = $0 }
+        ),
         onDismiss: self.onDismiss,
         content: { item in
           self.content(item)


### PR DESCRIPTION
At the moment, if `dismiss` is called inside the modals' content, `item` is not set to `nil` and `isPresented` is not set to `false`. This PR addresses this issue.