### PR TITLE
Re-enable animations inside modal presentation modifiers

### DIFF
--- a/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationModifier.swift
+++ b/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationModifier.swift
@@ -23,6 +23,9 @@ struct ModalPresentationModifier<Modal: View>: ViewModifier {
 
   func body(content: Content) -> some View {
     content
+      .transaction {
+        $0.disablesAnimations = false
+      }
       .onAppear {
         if self.isContentVisible {
           self.isPresented = true

--- a/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationWithItemModifier.swift
+++ b/Sources/ComponentsKit/Components/Modal/SwiftUI/Helpers/ModalPresentationWithItemModifier.swift
@@ -23,6 +23,9 @@ struct ModalPresentationWithItemModifier<Modal: View, Item: Identifiable>: ViewM
 
   func body(content: Content) -> some View {
     content
+      .transaction {
+        $0.disablesAnimations = false
+      }
       .onAppear {
         self.presentedItem = self.visibleItem
       }


### PR DESCRIPTION
### Problem
Placing any modal on a parent view unexpectedly turned off every SwiftUI animation in that parent hierarchy. Example:

```swift
VStack {
  SULoading()               // ← should spin
  Button("Show Modal") { isPresented.toggle() }
}
.bottomModal(isPresented: $isPresented) {
  Text("Modal Content")
}
```

Observed: the `SULoading` spinner froze as soon as the `bottomModal` is added—even though the modal is not presented.

#### Root cause
`ModalPresentationModifier` ended with:

```swift
.transaction { $0.disablesAnimations = true }
```

Because a `Transaction` propagates down the view tree, this flag disabled all descendant animations, including those unrelated to the modal itself.

### Fix
Immediately reset the flag for the caller’s content:

```swift
content                          // original body’s `content`
  .transaction { $0.disablesAnimations = false }   // ✅ re-enable for content
  ...
  .fullScreenCover { ... }
  .transaction { $0.disablesAnimations = true }    // 🚫 disable for `fullScreenCover`
```
* The inner `.transaction { … = false }` is higher in the hierarchy, so every animation in the caller’s view (including `SULoading`) now runs normally.
* The outer `.transaction { … = true }` still prevents unwanted implicit animations during presentation/dismissal state changes.
