### PR TITLE
Improve Card hit-testing and border rendering in SUCard

### DIFF
--- a/Sources/ComponentsKit/Components/Card/SUCard.swift
+++ b/Sources/ComponentsKit/Components/Card/SUCard.swift
@@ -58,6 +58,7 @@ public struct SUCard<Content: View>: View {
       )
       .shadow(self.model.shadow)
       .observeSize { self.contentSize = $0 }
+      .contentShape(.rect)
       .gesture(
         DragGesture(minimumDistance: 0.0)
           .onChanged { _ in

--- a/Sources/ComponentsKit/Components/Card/SUCard.swift
+++ b/Sources/ComponentsKit/Components/Card/SUCard.swift
@@ -51,7 +51,7 @@ public struct SUCard<Content: View>: View {
       .cornerRadius(self.model.cornerRadius.value)
       .overlay(
         RoundedRectangle(cornerRadius: self.model.cornerRadius.value)
-          .stroke(
+          .strokeBorder(
             self.model.borderColor.color,
             lineWidth: self.model.borderWidth.value
           )

--- a/Sources/ComponentsKit/Components/Card/SUCard.swift
+++ b/Sources/ComponentsKit/Components/Card/SUCard.swift
@@ -58,20 +58,22 @@ public struct SUCard<Content: View>: View {
       )
       .shadow(self.model.shadow)
       .observeSize { self.contentSize = $0 }
-      .simultaneousGesture(DragGesture(minimumDistance: 0.0)
-        .onChanged { _ in
-          guard self.model.isTappable else { return }
-          self.isPressed = true
-        }
-        .onEnded { value in
-          guard self.model.isTappable else { return }
-
-          defer { self.isPressed = false }
-
-          if CGRect(origin: .zero, size: self.contentSize).contains(value.location) {
-            self.onTap()
+      .gesture(
+        DragGesture(minimumDistance: 0.0)
+          .onChanged { _ in
+            guard self.model.isTappable else { return }
+            self.isPressed = true
           }
-        }
+          .onEnded { value in
+            guard self.model.isTappable else { return }
+
+            defer { self.isPressed = false }
+
+            if CGRect(origin: .zero, size: self.contentSize)
+              .contains(value.location) {
+              self.onTap()
+            }
+          }
       )
       .scaleEffect(
         self.isPressed ? self.model.animationScale.value : 1,

--- a/Sources/ComponentsKit/Components/Card/UKCard.swift
+++ b/Sources/ComponentsKit/Components/Card/UKCard.swift
@@ -138,10 +138,15 @@ open class UKCard<Content: UIView>: UIView, UKComponent {
     _ touches: Set<UITouch>,
     with event: UIEvent?
   ) {
+    guard self.model.isTappable,
+          let touch = touches.first,
+          touch.view == self
+    else {
+      super.touchesBegan(touches, with: event)
+      return
+    }
+
     super.touchesBegan(touches, with: event)
-
-    guard self.model.isTappable else { return }
-
     self.isPressed = true
   }
 
@@ -149,17 +154,21 @@ open class UKCard<Content: UIView>: UIView, UKComponent {
     _ touches: Set<UITouch>,
     with event: UIEvent?
   ) {
-    super.touchesEnded(touches, with: event)
-
-    guard self.model.isTappable else { return }
+    guard self.model.isTappable,
+          let touch = touches.first,
+          touch.view == self
+    else {
+      super.touchesEnded(touches, with: event)
+      return
+    }
 
     defer { self.isPressed = false }
 
-    if self.model.isTappable,
-       let location = touches.first?.location(in: self),
-       self.bounds.contains(location) {
+    let location = touch.location(in: self)
+    if bounds.contains(location) {
       self.onTap()
     }
+    super.touchesEnded(touches, with: event)
   }
 
   open override func touchesCancelled(

--- a/Sources/ComponentsKit/Components/Card/UKCard.swift
+++ b/Sources/ComponentsKit/Components/Card/UKCard.swift
@@ -138,15 +138,10 @@ open class UKCard<Content: UIView>: UIView, UKComponent {
     _ touches: Set<UITouch>,
     with event: UIEvent?
   ) {
-    guard self.model.isTappable,
-          let touch = touches.first,
-          touch.view == self
-    else {
-      super.touchesBegan(touches, with: event)
-      return
-    }
-
     super.touchesBegan(touches, with: event)
+
+    guard self.model.isTappable else { return }
+
     self.isPressed = true
   }
 
@@ -154,21 +149,17 @@ open class UKCard<Content: UIView>: UIView, UKComponent {
     _ touches: Set<UITouch>,
     with event: UIEvent?
   ) {
-    guard self.model.isTappable,
-          let touch = touches.first,
-          touch.view == self
-    else {
-      super.touchesEnded(touches, with: event)
-      return
-    }
+    super.touchesEnded(touches, with: event)
+
+    guard self.model.isTappable else { return }
 
     defer { self.isPressed = false }
 
-    let location = touch.location(in: self)
-    if bounds.contains(location) {
+    if self.model.isTappable,
+       let location = touches.first?.location(in: self),
+       self.bounds.contains(location) {
       self.onTap()
     }
-    super.touchesEnded(touches, with: event)
   }
 
   open override func touchesCancelled(


### PR DESCRIPTION
### Changes

1. **Problem: Border clipping**
Prevents half the border from being clipped by drawing the line inside the shape:
`.strokeBorder()` instead of `.stroke()`

2. **Problem: Taps don’t register on transparent areas**
Adding `.contentShape(.rect)` makes transparent regions tappable.

3. **Problem: Taps on child views trigger the card’s tap handler**
With isTappable enabled, any touch inside the card, including taps on buttons or checkboxes, still fires the card’s own tap action. Subviews should handle their taps independently.

**SwiftUI fix:**
Replaced the `.simultaneousGesture()` with `.gesture(DragGesture(minimumDistance: 0.0)...)`