### PR TITLE
isolate `SUCard` tap handling from nested controls

### DIFF
--- a/Sources/ComponentsKit/Components/Card/SUCard.swift
+++ b/Sources/ComponentsKit/Components/Card/SUCard.swift
@@ -59,22 +59,19 @@ public struct SUCard<Content: View>: View {
       .shadow(self.model.shadow)
       .observeSize { self.contentSize = $0 }
       .contentShape(.rect)
-      .gesture(
+      .onTapGesture {
+        guard self.model.isTappable else { return }
+        self.onTap()
+      }
+      .simultaneousGesture(
         DragGesture(minimumDistance: 0.0)
           .onChanged { _ in
-            guard self.model.isTappable else { return }
             self.isPressed = true
           }
-          .onEnded { value in
-            guard self.model.isTappable else { return }
-
-            defer { self.isPressed = false }
-
-            if CGRect(origin: .zero, size: self.contentSize)
-              .contains(value.location) {
-              self.onTap()
-            }
-          }
+          .onEnded { _ in
+            self.isPressed = false
+          },
+        isEnabled: self.model.isTappable
       )
       .scaleEffect(
         self.isPressed ? self.model.animationScale.value : 1,


### PR DESCRIPTION
This PR separates tap and drag handling in `SUCard` so that `onTap()` is invoked **only when the user taps the card itself**. Buttons, toggles, and other interactive subviews now work normally without triggering the card’s action.

**Known drawback:** the press-state scale animation still plays when a nested control is tapped because the `DragGesture` continues to detect the touch.
