### PR TITLE
Fix alert title text truncation

### DIFF
--- a/Sources/ComponentsKit/Components/Alert/SUAlert.swift
+++ b/Sources/ComponentsKit/Components/Alert/SUAlert.swift
@@ -60,6 +60,7 @@ struct AlertContent: View {
       .foregroundStyle(UniversalColor.foreground.color)
       .multilineTextAlignment(.center)
       .frame(maxWidth: .infinity)
+      .fixedSize(horizontal: false, vertical: true)
   }
 
   func message(_ text: String) -> some View {


### PR DESCRIPTION
Fix alert title text truncation by enabling line wrapping with `.fixedSize`