### PR TITLE
Fix `UKButton` and `UKCard` actions not triggered when parent has gesture recognizer

### DIFF
--- a/Sources/ComponentsKit/Components/Button/UKButton.swift
+++ b/Sources/ComponentsKit/Components/Button/UKButton.swift
@@ -199,7 +199,13 @@ open class UKButton: FullWidthComponent, UKComponent {
   ) {
     super.touchesCancelled(touches, with: event)
 
-    self.isPressed = false
+    defer { self.isPressed = false }
+
+    if self.model.isInteractive,
+       let location = touches.first?.location(in: self),
+       self.bounds.contains(location) {
+      self.action()
+    }
   }
 
   open override func traitCollectionDidChange(

--- a/Sources/ComponentsKit/Components/Card/UKCard.swift
+++ b/Sources/ComponentsKit/Components/Card/UKCard.swift
@@ -170,7 +170,15 @@ open class UKCard<Content: UIView>: UIView, UKComponent {
   ) {
     super.touchesCancelled(touches, with: event)
 
-    self.isPressed = false
+    guard self.model.isTappable else { return }
+
+    defer { self.isPressed = false }
+
+    if self.model.isTappable,
+       let location = touches.first?.location(in: self),
+       self.bounds.contains(location) {
+      self.onTap()
+    }
   }
 
   open override func traitCollectionDidChange(


### PR DESCRIPTION
When a `UKButton` or `UKCard` is placed inside a parent view that has a gesture recognizer, their actions are not triggered because the touch events are canceled.

This PR addresses the issue by triggering the action on `touchesCancelled`, ensuring that the component still responds even if the system cancels the touch due to gesture conflicts.

